### PR TITLE
Bump version of gfx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuklear-backend-gfx"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Serhii Plyhun <snuk188@gmail.com>"]
 keywords = ["widgets", "gui", "interface", "graphics", "gfx"]
 description = "A gfx-rs drawing backend for Rust wrapper for Nuklear 2D GUI library"
@@ -15,6 +15,6 @@ path = "src/lib.rs"
 
 [dependencies]
 log = "~0.3"
-gfx = "~0.15"
+gfx = "~0.16"
 nuklear-rust = "~0.3"
 


### PR DESCRIPTION
I don't really see any reason to not update the dependency, except that it breaks the code in nuklear-test. Thats why I also bumped the version of this crate. I'll open a PR on nuklear-test that fixes it to work with the latest gfx and glutin.